### PR TITLE
Adjust ports for local development

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -14,7 +14,7 @@ hibernate.hbm2ddl.auto=update
 hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 
 server.address=0.0.0.0
-server.port=9090
+server.port=4444
 #server.error.include-stacktrace=never
 #server.error.include-message=never
 

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_BASE_URL=http://localhost:9090/
+NEXT_PUBLIC_BASE_URL=http://localhost:4444/


### PR DESCRIPTION
## Summary
- configure backend to run on port 4444
- match frontend development URL to backend

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68642359abf08322b225afb9a65fd984